### PR TITLE
Added data-related structs

### DIFF
--- a/average.go
+++ b/average.go
@@ -1,0 +1,53 @@
+package counter
+
+import (
+	"errors"
+	"fmt"
+)
+
+// NewAverage initializes a new Average by setting private values.
+// This function is intended for instantiating an Average using data
+// from an outiside data store.
+//
+// Note that new(Average) is equivalent to NewAverage(0, 0).
+func NewAverage(value float64, count int) *Average {
+	return &Average{
+		value: value,
+		count: count,
+	}
+}
+
+// Average represents an action's cumulative average.
+type Average struct {
+	count int
+	value float64
+}
+
+// Add adds a new value to the cumulative average.
+func (a *Average) Add(newVal int) error {
+	if newVal <= 0 {
+		return fmt.Errorf("Average.Add called with non-positive value %d", newVal)
+	}
+	if a.count+1 < 0 {
+		return errors.New("Average.count overflow - cannot add to this Average")
+	}
+
+	newCount := float64(a.count + 1)
+	largerRatio := (newCount - 1) / newCount
+	smallerRatio := float64(1) / newCount
+
+	largerPortion := largerRatio * a.value
+	smallerPortion := smallerRatio * float64(newVal)
+	newAverage := largerPortion + smallerPortion
+
+	a.value = newAverage
+	a.count++
+
+	return nil
+}
+
+// Count returns the number of data points in the calculated average.
+func (a *Average) Count() int { return a.count }
+
+// Value returns the calculated average value.
+func (a *Average) Value() float64 { return a.value }

--- a/average_test.go
+++ b/average_test.go
@@ -31,7 +31,7 @@ func TestAverageAddMany(t *testing.T) {
 	for i, c := range cases {
 		err := average.Add(c.value)
 		if err != nil {
-			t.Fatalf("case %d failed: unexpected error %v", i, err)
+			t.Fatalf("case %d failed: unexpected error: %v", i, err)
 		}
 
 		assertAccurate(t, c.expectedAverage, average.value,
@@ -168,7 +168,7 @@ func TestAverageEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.avg.Add(tt.addValue)
 			if !tt.shouldErr && err != nil {
-				t.Fatalf("unexpected error %v", err)
+				t.Fatalf("unexpected error: %v", err)
 			}
 
 			if tt.shouldErr {

--- a/average_test.go
+++ b/average_test.go
@@ -1,0 +1,198 @@
+package counter
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+	"testing"
+)
+
+const requiredPercentAccuracy = 0.99999 // 99.999% ("five nines")
+
+// assertAccurate checks that the actual value differs from the expected
+// less than the required percentage.
+func assertAccurate(t *testing.T, expected, actual float64, failMsg string) {
+	if (actual / expected) < requiredPercentAccuracy {
+		t.Fatalf(failMsg)
+	}
+}
+
+func TestAverageAddMany(t *testing.T) {
+	cases := []struct {
+		value           int
+		expectedAverage float64
+	}{
+		{value: 10, expectedAverage: 10},
+		{value: 5, expectedAverage: 7.5},
+		{value: 8, expectedAverage: 23.0 / 3},
+	}
+
+	average := new(Average)
+	for i, c := range cases {
+		err := average.Add(c.value)
+		if err != nil {
+			t.Fatalf("case %d failed: unexpected error %v", i, err)
+		}
+
+		assertAccurate(t, c.expectedAverage, average.value,
+			fmt.Sprintf(`case %d failed:
+	adding value: %d
+	expected average: %f 
+	actual average: %f`,
+				i, c.value, c.expectedAverage, average.value),
+		)
+	}
+}
+
+func TestAverageAccuracy(t *testing.T) {
+	// Averaging the same value repeatedly will surface any noticeable
+	// loss in accuracy from imprecise float representation.
+	avg := new(Average)
+	const (
+		val            = 5555
+		floatVal       = float64(val)
+		requiredRounds = 1e6 // 1 million actions
+	)
+
+	for i := 0; i < requiredRounds; i++ {
+		err := avg.Add(val)
+		if err != nil {
+			t.Fatalf("case %d failed: unexpected error %v", i, err)
+		}
+		assertAccurate(t, floatVal, avg.value,
+			fmt.Sprintf("Loss of precision exceeded acceptable values by %d round: %f",
+				i, (avg.value/floatVal)),
+		)
+	}
+}
+
+// maxInt calculates the maximum integer value regardless of
+// the operating system.
+func maxInt() int {
+	// Operations on signed integers behave differently from unsigned integers,
+	// so we will use unsigned and convert at the end.
+	// The end of this section discusses the two operators used
+	// in this function: https://golang.org/ref/spec#Arithmetic_operators
+	//
+	// Relies on the fact that uint and int are the same number of bits,
+	// differing by a sign flag on the leftmost bit for int.
+	// See: https://golang.org/ref/spec#Numeric_types
+	allOnes := ^uint(0)
+
+	// Leftmost bit of 1 will indicate a negative, so we need to change
+	// it to 0. Shift operation fills "empty" space with 0.
+	toggledSign := allOnes >> 1
+
+	return int(toggledSign)
+}
+
+func TestMaxInt(t *testing.T) {
+	actual := maxInt()
+	var expected int64 = math.MaxInt32
+	if bits.UintSize == 64 {
+		// This line will not compile on a 32 bit system if the type of
+		// "expected" is not int64. It will compile without error on a
+		// 64 bit system if type is int.
+		expected = math.MaxInt64
+	}
+	if int64(actual) != expected {
+		t.Fatalf("Maxint (%d) was not correctly calculated for Uintsize %d", actual, bits.UintSize)
+	}
+}
+
+func TestAverageEdgeCases(t *testing.T) {
+	// The expected values here were calculated using Wolfram Alpha,
+	// as most calculators will display less precision.
+	tts := []struct {
+		name     string
+		avg      Average
+		addValue int
+
+		shouldErr   bool
+		errorMsg    string
+		expectedAvg Average
+	}{
+		{
+			name: "start max average",
+			avg: Average{
+				count: 11,
+				value: float64(math.MaxInt64),
+			},
+			addValue: 1,
+			expectedAvg: Average{
+				count: 12,
+				value: 8454757700450211157 + 5.0/12,
+			},
+		}, {
+			name: "start max count",
+			avg: Average{
+				count: maxInt(),
+				value: 10,
+			},
+			addValue:  1,
+			shouldErr: true,
+			errorMsg:  "Average.count overflow - cannot add to this Average",
+		}, {
+			name: "zero addition",
+			avg: Average{
+				count: 5,
+				value: 10,
+			},
+			addValue:  0,
+			shouldErr: true,
+			errorMsg:  "Average.Add called with non-positive value 0",
+		}, {
+			name: "negative addition",
+			avg: Average{
+				count: 5,
+				value: 10,
+			},
+			addValue:  -1,
+			shouldErr: true,
+			errorMsg:  "Average.Add called with non-positive value -1",
+		}, {
+			name: "max addition",
+			avg: Average{
+				count: 500,
+				value: 10,
+			},
+			addValue: maxInt(),
+			expectedAvg: Average{
+				count: 501,
+				value: 18409924225259043 + 265.0/501,
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.avg.Add(tt.addValue)
+			if !tt.shouldErr && err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			if tt.shouldErr {
+				assertEqual(t, tt.errorMsg, err.Error(), "error message")
+				return
+			}
+			assertAccurate(t, tt.expectedAvg.value, tt.avg.value,
+				fmt.Sprintf("\nexpected average: %+v\nactual average: %+v",
+					tt.expectedAvg, tt.avg))
+		})
+	}
+}
+
+func TestAverageHelpers(t *testing.T) {
+	const (
+		val = 8
+		ct  = 30
+	)
+	actual := NewAverage(val, ct)
+	expected := &Average{
+		value: val,
+		count: ct,
+	}
+	assertEqual(t, *expected, *actual, "average")
+	assertEqual(t, actual.Value(), actual.value, "value")
+	assertEqual(t, actual.Count(), actual.count, "count")
+}

--- a/store.go
+++ b/store.go
@@ -1,0 +1,44 @@
+package counter
+
+import (
+	"errors"
+	"strings"
+	"sync"
+)
+
+const uninitializedError = "data store was not initialized"
+
+// store is the default datastore for the action counter.
+// It notably converts all alpha characters to lower case,
+// does not handle its own lock, and does not validate data.
+type store struct {
+	data map[string]*Average
+	sync.RWMutex
+}
+
+// Add adds a value to the count for the given action.
+// It will ignore case and assumes that the lock has
+// already been obtained by the caller.
+func (s *store) Add(action string, value int) error {
+	if s == nil || s.data == nil {
+		return errors.New(uninitializedError)
+	}
+
+	action = strings.ToLower(action)
+	if s.data[action] == nil {
+		s.data[action] = new(Average)
+	}
+
+	return s.data[action].Add(value)
+}
+
+// Get retrieves a copy of the store's data.
+// It is not safe to modify and assumes that the
+// caller obtained the lock.
+func (s *store) Get() (map[string]*Average, error) {
+	if s == nil || s.data == nil {
+		return nil, errors.New(uninitializedError)
+	}
+
+	return s.data, nil
+}

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,36 @@
+package counter
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestStoreHappyPath(t *testing.T) {
+	s := store{
+		data:    map[string]*Average{},
+		RWMutex: sync.RWMutex{},
+	}
+
+	err := s.Add("jump", 20)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = s.Add("Jump", 30)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := s.Get()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertEqual(t, float64(25), data["jump"].Value(), "average")
+}
+
+func TestNilHandling(t *testing.T) {
+	var s store
+	err := s.Add("anything", 5)
+	assertEqual(t, uninitializedError, err.Error(), "error")
+	_, err = s.Get()
+	assertEqual(t, uninitializedError, err.Error(), "error")
+}

--- a/testhelper.go
+++ b/testhelper.go
@@ -1,0 +1,9 @@
+package counter
+
+import "testing"
+
+func assertEqual(t *testing.T, expected, actual interface{}, name string) {
+	if expected != actual {
+		t.Fatalf("\nexpected %s: %+v\nactual %s: %+v", expected, name, actual, name)
+	}
+}


### PR DESCRIPTION
This PR adds the first iteration of data related structs, with testing.

I chose the below method for calculating an average because it allows for larger numbers. Other possible methods include:
- Keep the sum and count of all action values thus far. The drawback here is that large numbers may overflow quickly, but it has the advantage of greater accuracy and faster insertion time.
- Keep all values of actions thus far in a list. This one isn't efficient, memory-wise, and would make retrieving data extremely slow for large input quantity. It also wouldn't necessarily be fast to insert, given the list might need to allocate more data. Finally, it would limit choice in external data stores to those that work well with lists. However, it would allow us to return more variety of calculations than average, if the need ever arose.

Constant requiredPercentAccuracy was chosen based on the "five nines" goal for hosting as well as the measurement of purity for chemical substances, but is more or less an arbitrary number until a case is made for something more accurate.

Likewise, requiredRounds was chosen arbitrarily to be large in terms of actions, but small in terms of time to run. This can be changed if needed, but anything greater than the current magnitude may require adding a testing flag for a long running test time (see https://golang.org/pkg/testing/#Short).