### PR TITLE
Added controller for action counter

### DIFF
--- a/action.go
+++ b/action.go
@@ -1,0 +1,28 @@
+package counter
+
+import "encoding/json"
+
+type actionAddition struct {
+	Action string `json:"action"`
+	Time   int    `json:"time"`
+}
+
+type stats map[string]*Average
+
+func (ss stats) MarshalJSON() ([]byte, error) {
+	list := make([]stat, len(ss))
+	var i int
+	for action, avg := range ss {
+		list[i] = stat{
+			Action:  action,
+			Average: avg.IntValue(),
+		}
+		i++
+	}
+	return json.Marshal(list)
+}
+
+type stat struct {
+	Action  string `json:"action"`
+	Average int    `json:"avg"`
+}

--- a/action.go
+++ b/action.go
@@ -2,13 +2,16 @@ package counter
 
 import "encoding/json"
 
+// actionAddition is the action "request" struct.
 type actionAddition struct {
 	Action string `json:"action"`
 	Time   int    `json:"time"`
 }
 
+// stats aliases a map of an action to an average to enable custom marshaling.
 type stats map[string]*Average
 
+// MarhsalJSON converts stats to a list of stat structs.
 func (ss stats) MarshalJSON() ([]byte, error) {
 	list := make([]stat, len(ss))
 	var i int
@@ -22,6 +25,7 @@ func (ss stats) MarshalJSON() ([]byte, error) {
 	return json.Marshal(list)
 }
 
+// stat is the action average "response" struct.
 type stat struct {
 	Action  string `json:"action"`
 	Average int    `json:"avg"`

--- a/action_test.go
+++ b/action_test.go
@@ -1,0 +1,40 @@
+package counter
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStatsMarshal(t *testing.T) {
+	tts := []struct {
+		name     string
+		data     map[string]*Average
+		expected string
+	}{
+		{
+			name: "filled data",
+			data: map[string]*Average{
+				"jump": &Average{value: 5.2},
+				"run":  &Average{value: 3.6},
+			},
+			expected: `[{"action":"jump","avg":5},{"action":"run","avg":4}]`,
+		}, {
+			name:     "empty map",
+			data:     map[string]*Average{},
+			expected: "[]",
+		}, {
+			name:     "nil map",
+			expected: "[]",
+		},
+	}
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := json.Marshal(stats(tt.data))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// Convert to string because slices aren't inherently comparable.
+			assertEqual(t, tt.expected, string(actual), "marshaled data")
+		})
+	}
+}

--- a/average.go
+++ b/average.go
@@ -3,6 +3,7 @@ package counter
 import (
 	"errors"
 	"fmt"
+	"math"
 )
 
 // NewAverage initializes a new Average by setting private values.
@@ -51,3 +52,8 @@ func (a *Average) Count() int { return a.count }
 
 // Value returns the calculated average value.
 func (a *Average) Value() float64 { return a.value }
+
+// IntValue returns an integar represation of the average value, rounded.
+func (a *Average) IntValue() int {
+	return int(math.Round(a.value))
+}

--- a/average.go
+++ b/average.go
@@ -8,7 +8,7 @@ import (
 
 // NewAverage initializes a new Average by setting private values.
 // This function is intended for instantiating an Average using data
-// from an outiside data store.
+// from an outside data store.
 //
 // Note that new(Average) is equivalent to NewAverage(0, 0).
 func NewAverage(value float64, count int) *Average {
@@ -37,9 +37,7 @@ func (a *Average) Add(newVal int) error {
 	largerRatio := (newCount - 1) / newCount
 	smallerRatio := float64(1) / newCount
 
-	largerPortion := largerRatio * a.value
-	smallerPortion := smallerRatio * float64(newVal)
-	newAverage := largerPortion + smallerPortion
+	newAverage := largerRatio*a.value + smallerRatio*float64(newVal)
 
 	a.value = newAverage
 	a.count++
@@ -53,7 +51,7 @@ func (a *Average) Count() int { return a.count }
 // Value returns the calculated average value.
 func (a *Average) Value() float64 { return a.value }
 
-// IntValue returns an integar represation of the average value, rounded.
+// IntValue returns an integer representation of the average value, rounded.
 func (a *Average) IntValue() int {
 	return int(math.Round(a.value))
 }

--- a/average_test.go
+++ b/average_test.go
@@ -10,14 +10,14 @@ import (
 const requiredPercentAccuracy = 0.99999 // 99.999% ("five nines")
 
 // assertAccurate checks that the actual value differs from the expected
-// less than the required percentage.
+// within acceptable range.
 func assertAccurate(t *testing.T, expected, actual float64, failMsg string) {
 	if (actual / expected) < requiredPercentAccuracy {
 		t.Fatalf(failMsg)
 	}
 }
 
-func TestAverageAddMany(t *testing.T) {
+func TestAverageAddLayering(t *testing.T) {
 	cases := []struct {
 		value           int
 		expectedAverage float64
@@ -49,8 +49,14 @@ func TestAverageAccuracy(t *testing.T) {
 	// loss in accuracy from imprecise float representation.
 	avg := new(Average)
 	const (
-		val            = 5555
-		floatVal       = float64(val)
+		val      = 5555
+		floatVal = float64(val)
+
+		// The following was an arbitrarily chosen large number.
+		// This test may need to increase this depending on expected
+		// use. If it increases, this test should potentially use
+		// if testing.Short() { t.Skip() }
+		// due to increased runtime.
 		requiredRounds = 1e6 // 1 million actions
 	)
 
@@ -176,8 +182,9 @@ func TestAverageEdgeCases(t *testing.T) {
 				return
 			}
 			assertAccurate(t, tt.expectedAvg.value, tt.avg.value,
-				fmt.Sprintf("\nexpected average: %+v\nactual average: %+v",
+				fmt.Sprintf("\nexpected average value: %+v\nactual average value: %+v",
 					tt.expectedAvg, tt.avg))
+			assertEqual(t, tt.expectedAvg.count, tt.avg.count, "average count")
 		})
 	}
 }
@@ -202,9 +209,9 @@ func TestIntAverage(t *testing.T) {
 		value    float64
 		expected int
 	}{
-		{value: 0, expected: 0},
-		{value: 10.1, expected: 10},
-		{value: 10.5, expected: 11},
+		{value: 0, expected: 0},     // no round
+		{value: 10.1, expected: 10}, // round down
+		{value: 10.5, expected: 11}, // round up
 	}
 
 	for _, tt := range tts {

--- a/average_test.go
+++ b/average_test.go
@@ -196,3 +196,21 @@ func TestAverageHelpers(t *testing.T) {
 	assertEqual(t, actual.Value(), actual.value, "value")
 	assertEqual(t, actual.Count(), actual.count, "count")
 }
+
+func TestIntAverage(t *testing.T) {
+	tts := []struct {
+		value    float64
+		expected int
+	}{
+		{value: 0, expected: 0},
+		{value: 10.1, expected: 10},
+		{value: 10.5, expected: 11},
+	}
+
+	for _, tt := range tts {
+		t.Run(fmt.Sprintf("%f rounds to %d", tt.value, tt.expected), func(t *testing.T) {
+			avg := Average{value: tt.value}
+			assertEqual(t, tt.expected, avg.IntValue(), "rounded value")
+		})
+	}
+}

--- a/counter.go
+++ b/counter.go
@@ -1,0 +1,68 @@
+package counter
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DataStore is an interface for handling new actions.
+type DataStore interface {
+	Lock()
+	Unlock()
+	RLock()
+	RUnlock()
+	Add(action string, value int) error
+	Get() (map[string]*Average, error)
+}
+
+// ActionCounter manages adding and retrieving action averages.
+type ActionCounter struct {
+	DataStore DataStore
+}
+
+// AddAction takes marshaled json and adds it to the data store.
+func (ac *ActionCounter) AddAction(jsonString string) error {
+	var aa actionAddition
+	err := json.Unmarshal([]byte(jsonString), &aa)
+	if err != nil {
+		return fmt.Errorf("error parsing action json: %v", err)
+	}
+	return ac.add(aa)
+}
+
+// GetStats returns the average of each action stat given.
+func (ac *ActionCounter) GetStats() string {
+	// Locking cannot happen closer to retrieving the map
+	// It must stay locked until it finishes unmarshaling,
+	// as a simultaneous write could cause a panic.
+	//
+	// Note that unlock will still happen if the below panic
+	// is triggered.
+	ac.DataStore.RLock()
+	defer ac.DataStore.RUnlock()
+
+	data, err := ac.DataStore.Get()
+	if err != nil {
+		// Leave error handling to caller.
+		// Either the datastore wasn't initialized, or caller is
+		// using a custom implementation. If panic is not acceptable,
+		// Wrap this call in a function that returns (string, error).
+		panic(err)
+	}
+
+	// We have no way of handling this error, and unlike the previous case,
+	// it isn't worth panicking over. We need to instead have full test coverage.
+	resp, _ := json.Marshal(stats(data))
+	return string(resp)
+}
+
+func (ac *ActionCounter) add(aa actionAddition) error {
+	if aa.Time < 1 {
+		return fmt.Errorf("non-positive time given to ActionCounter: %d", aa.Time)
+	}
+	ac.DataStore.Lock()
+	err := ac.DataStore.Add(aa.Action, aa.Time)
+	// Using defer adds overhead unnecessarily when there's only one place to unlock.
+	ac.DataStore.Unlock()
+	return err
+}

--- a/counter.go
+++ b/counter.go
@@ -56,10 +56,13 @@ func (ac *ActionCounter) GetStats() string {
 	return string(resp)
 }
 
+// add handles the actual adding. It manages data validation and locking.
 func (ac *ActionCounter) add(aa actionAddition) error {
 	if aa.Time < 1 {
 		return fmt.Errorf("non-positive time given to ActionCounter: %d", aa.Time)
 	}
+	// Unlike reading, writing should lock as close to the write call as possible because
+	// no interactions with given data happen after this point.
 	ac.DataStore.Lock()
 	err := ac.DataStore.Add(aa.Action, aa.Time)
 	// Using defer adds overhead unnecessarily when there's only one place to unlock.

--- a/counter_test.go
+++ b/counter_test.go
@@ -1,0 +1,165 @@
+package counter
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+const innerError = "an error was ordered"
+
+func TestCounterAddActionInvalidJSON(t *testing.T) {
+	ts := newTestStore()
+	ac := ActionCounter{
+		DataStore: &ts,
+	}
+
+	err := ac.AddAction(`{"action:"jump","time":30}`)
+	if err == nil {
+		t.Fatalf("got nil instead of expected error")
+	}
+
+	assertEqual(t, "error parsing action json: invalid character 'j' after object key",
+		err.Error(), "error message")
+	// Ensure we didn't waste time locking.
+	assertEqual(t, false, ts.wasLocked, "was locked")
+}
+
+func TestCounterAddInvalidTime(t *testing.T) {
+	ts := newTestStore()
+	ac := ActionCounter{
+		DataStore: &ts,
+	}
+
+	err := ac.add(actionAddition{
+		Action: "fly",
+		Time:   -30,
+	})
+	if err == nil {
+		t.Fatalf("got nil instead of expected error")
+	}
+
+	assertEqual(t, "non-positive time given to ActionCounter: -30", err.Error(), "error message")
+	// Ensure we didn't waste time locking.
+	assertEqual(t, false, ts.wasLocked, "was locked")
+}
+
+func TestCounterAddError(t *testing.T) {
+	ts := newTestStore()
+	ac := ActionCounter{
+		DataStore: &ts,
+	}
+	ts.returnError = true
+
+	err := ac.add(actionAddition{
+		Action: "fly",
+		Time:   30,
+	})
+	if err == nil {
+		t.Fatalf("got nil instead of expected error")
+	}
+
+	assertEqual(t, innerError, err.Error(), "error message")
+	assertEqual(t, true, ts.wasUnlocked, "was unlocked")
+}
+
+func TestCounterAdd(t *testing.T) {
+	ts := newTestStore()
+	ac := ActionCounter{
+		DataStore: &ts,
+	}
+
+	err := ac.add(actionAddition{
+		Action: "fly",
+		Time:   30,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertEqual(t, true, ts.addCalled, "add called")
+	assertEqual(t, true, ts.wasLocked, "was locked")
+	assertEqual(t, true, ts.wasUnlocked, "was unlocked")
+}
+
+func TestGetStats(t *testing.T) {
+	ts := newTestStore()
+	ac := ActionCounter{
+		DataStore: &ts,
+	}
+
+	ss := ac.GetStats()
+	assertEqual(t, `[{"action":"swim","avg":31}]`, ss, "stats")
+	assertEqual(t, true, ts.wasRLocked, "was read locked")
+	assertEqual(t, true, ts.wasRUnlocked, "was read unlocked")
+}
+
+func TestGetStatsPanic(t *testing.T) {
+	ts := newTestStore()
+	ac := ActionCounter{
+		DataStore: &ts,
+	}
+	ts.returnError = true
+
+	defer func() {
+		if r := recover(); r != nil {
+			assertEqual(t, true, ts.wasRLocked, "was read locked")
+			assertEqual(t, true, ts.wasRUnlocked, "was read unlocked")
+		} else {
+			t.Fatal("did not panic")
+		}
+	}()
+
+	ac.GetStats()
+}
+
+func newTestStore() testStore {
+	return testStore{store: &store{
+		data: map[string]*Average{
+			"swim": &Average{
+				count: 70,
+				value: 30.88,
+			},
+		},
+		RWMutex: sync.RWMutex{},
+	}}
+}
+
+type testStore struct {
+	wasLocked, wasUnlocked, wasRLocked, wasRUnlocked bool
+	addCalled, getCalled                             bool
+	returnError                                      bool
+	*store
+}
+
+func (ts *testStore) Lock() {
+	ts.wasLocked = true
+}
+
+func (ts *testStore) Unlock() {
+	ts.wasUnlocked = true
+}
+
+func (ts *testStore) RLock() {
+	ts.wasRLocked = true
+}
+
+func (ts *testStore) RUnlock() {
+	ts.wasRUnlocked = true
+}
+
+func (ts *testStore) Add(_ string, _ int) error {
+	ts.addCalled = true
+	if ts.returnError {
+		return errors.New(innerError)
+	}
+	return nil
+}
+
+func (ts *testStore) Get() (map[string]*Average, error) {
+	ts.getCalled = true
+	if ts.returnError {
+		return nil, errors.New(innerError)
+	}
+	return ts.store.Get()
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,85 @@
+package counter_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+
+	counter "github.com/nat-brown/action-counter"
+)
+
+func Example() {
+	ac := counter.ActionCounter{
+		DataStore: counter.DefaultDataStore(),
+	}
+
+	type action struct {
+		action string
+		time   int
+	}
+	actions := []action{
+		{action: "jump", time: 30},
+		{action: "run", time: 3600},
+		{action: "run", time: 3300},
+		{action: "jump", time: 30},
+		{action: "run", time: 3337},
+		{action: "swim", time: 250},
+		{action: "jump", time: 32},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(actions))
+	for _, a := range actions {
+		go func(a action) {
+			request := fmt.Sprintf(`{"action":"%s","time":%d}`, a.action, a.time)
+			err := ac.AddAction(request)
+			if err != nil {
+				fmt.Println(err)
+			}
+			wg.Done()
+		}(a)
+	}
+	wg.Wait()
+
+	output := ac.GetStats()
+	fmt.Println(sortKeys(output))
+
+	// Output:
+	// [{"action":"jump","avg":31},{"action":"run","avg":3412},{"action":"swim","avg":250}]
+}
+
+func ExampleActionCounter() {
+	ac := counter.ActionCounter{
+		DataStore: counter.DefaultDataStore(),
+	}
+
+	output := ac.GetStats()
+	fmt.Println(output)
+
+	ac.AddAction(`{"action":"jump", "time":100}`)
+	ac.AddAction(`{"action":"run", "time":75}`)
+	ac.AddAction(`{"action":"jump", "time":200}`)
+
+	output = ac.GetStats()
+	fmt.Println(sortKeys(output))
+
+	// Output:
+	// []
+	// [{"action":"jump","avg":150},{"action":"run","avg":75}]
+}
+
+func sortKeys(output string) string {
+	averages := []struct {
+		Action string `json:"action"`
+		Avg    int    `json:"avg"`
+	}{}
+	json.Unmarshal([]byte(output), &averages)
+
+	sort.Slice(averages, func(i, j int) bool {
+		return averages[i].Action < averages[j].Action
+	})
+
+	b, _ := json.Marshal(averages)
+	return string(b)
+}

--- a/store.go
+++ b/store.go
@@ -42,7 +42,7 @@ func (s *store) Add(action string, value int) error {
 }
 
 // Get retrieves a copy of the store's data.
-// It is not safe to modify and assumes that the
+// The data is not necessarily safe to modify and assumes that the
 // caller obtained the lock.
 func (s *store) Get() (map[string]*Average, error) {
 	if s == nil || s.data == nil {

--- a/store.go
+++ b/store.go
@@ -8,6 +8,15 @@ import (
 
 const uninitializedError = "data store was not initialized"
 
+// DefaultDataStore returns an instance of store with initialized values.
+// Also handles enforcement of store implementing the DataStore interface.
+func DefaultDataStore() DataStore {
+	return &store{
+		data:    map[string]*Average{},
+		RWMutex: sync.RWMutex{},
+	}
+}
+
 // store is the default datastore for the action counter.
 // It notably converts all alpha characters to lower case,
 // does not handle its own lock, and does not validate data.

--- a/store_test.go
+++ b/store_test.go
@@ -29,8 +29,21 @@ func TestStoreHappyPath(t *testing.T) {
 
 func TestNilHandling(t *testing.T) {
 	var s store
-	err := s.Add("anything", 5)
-	assertEqual(t, uninitializedError, err.Error(), "error")
-	_, err = s.Get()
-	assertEqual(t, uninitializedError, err.Error(), "error")
+	var p *store
+	tts := []struct {
+		name  string
+		store DataStore
+	}{
+		{name: "nil map", store: &s},
+		{name: "nil pointer", store: p},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.store.Add("anything", 5)
+			assertEqual(t, uninitializedError, err.Error(), "error")
+			_, err = tt.store.Get()
+			assertEqual(t, uninitializedError, err.Error(), "error")
+		})
+	}
 }

--- a/testhelper.go
+++ b/testhelper.go
@@ -4,6 +4,6 @@ import "testing"
 
 func assertEqual(t *testing.T, expected, actual interface{}, name string) {
 	if expected != actual {
-		t.Fatalf("\nexpected %s: %+v\nactual %s: %+v", expected, name, actual, name)
+		t.Fatalf("\nexpected %s: %+v\nactual %s: %+v", name, expected, name, actual)
 	}
 }


### PR DESCRIPTION
The PR adds the controller for the Action Counter, with tests. I was on the fence about including the cleanup commit in this PR, or moving it to its own given the non-functional nature of the changes and the fact that they only affect already touched files.

The specification of the interface didn't make it clear if the response average should be an integer or float. JSON doesn't differentiate between them, but considering this is a library for a strongly typed language, it matters. Since the user is giving an integer, I chose to respond in kind, but it would be a simple change to correct. My reasoning was that if they wanted more precision, the user would decrease their unit's magnitude (go from second to microsecond) and work with larger numbers. Floats were used in the calculations to preserve accuracy as much as possible.