### PR TITLE
updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,79 @@
 # Action-Counter
-a json time counter for actions
+
+This library provides a simple tool for tracking actions and their average times in a concurrency-safe manner. It provides two functions:
+* Add an action
+* Retrieve current averages
+
+Using it would look similar to below:
+```
+package anything
+
+import (
+    "fmt"
+    counter "github.com/nat-brown/action-counter"
+)
+
+func CountSomeActions() {
+    ac := counter.ActionCounter{
+        DataStore: counter.DefaultDataStore(),
+    }
+
+    ac.AddAction(`{"action":"jump", "time":100}`)
+    ac.AddAction(`{"action":"run", "time":75}`)
+    ac.AddAction(`{"action":"jump", "time":200}`)
+
+    output = ac.GetStats()
+    fmt.Println(output) // [{"action":"jump","avg":150},{"action":"run","avg":75}]
+}
+```
+---
+## Interface
+
+The action counter works exclusively in serialized json strings.
+
+#### Adding an action
+
+Action additions expect a json object containing two attributes: `action` and `time`. `time` must be positive and non-zero, while `action` is not case-sensitive and will always be stored as the lowercase version. Extra key-value pairs will be ignored.
+
+If your project requires case-sensitivity or other action name/time specifications, you can define your own object implementing the `DataStore` interface.
+
+Note that `time > 0` is a requirement handled outside of `DataStore`. Any limitations added on the `DataStore` level will stack with that requirement.
+
+#### Retrieving statistics
+
+Retrieved statistics will be a list of json objects containing an `action` and its corresponding average, `avg`. `action` will be a string and `avg` will always be an integer value, rounded to the nearest integer from the calculated average.
+
+#### The DataStore interface
+
+While this library works concurrently, it may not work for your needs with the default DataStore, such as in the case of a distributed system. If you need custom data storage and retrieval, or different constraints on input, this interface makes room for that.
+
+The `Average` struct has public functions to facilitate retrieving data from other sources, instantiating an `Average` instance, letting it take care of the averaging logic, and then pushing the result back to the database.
 
 ---
+## Installation
 
+This package assumes that you have a working Go environment. It has been tested in go version 1.11, but does not use dependencies that would likely prohibit earlier versions.
+
+To install the `counter` library, run the following `go get` command
+
+```
+go get github.com/nat-brown/action-counter
+```
+
+It can now be imported into go code.
+
+```
+import (
+    counter "github.com/nat-brown/action-counter"
+)
+```
+
+---
+## Running Tests
+
+Tests can be run with the `go test` command, or `go test -v` for a list of all tests being run. For more options on running tests, you can read more [here]().
+
+---
+## Go Docs
+
+This repository was written with godoc in mind. To run godoc, you can read instructions [here](https://godoc.org/golang.org/x/tools/cmd/godoc).

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import (
 ---
 ## Running Tests
 
-Tests can be run with the `go test` command, or `go test -v` for a list of all tests being run. For more options on running tests, you can read more [here]().
+Tests can be run with the `go test` command, or `go test -v` for a list of all tests being run. For more options on running tests, you can read more [here](https://golang.org/pkg/cmd/go/internal/test/).
 
 ---
 ## Go Docs

--- a/counter.go
+++ b/counter.go
@@ -1,3 +1,5 @@
+// Package counter provides a library for tracking action times and returning
+// their averages.
 package counter
 
 import (
@@ -7,11 +9,18 @@ import (
 
 // DataStore is an interface for handling new actions.
 type DataStore interface {
+	// Locks are intended to behave as with sync.RWMutex
 	Lock()
 	Unlock()
 	RLock()
 	RUnlock()
+
+	// Add retrieves the given action and adds the given
+	// value to its average.
+	// See the Average struct for details.
 	Add(action string, value int) error
+
+	// Get retrieves all actions and their averages.
 	Get() (map[string]*Average, error)
 }
 

--- a/store.go
+++ b/store.go
@@ -8,9 +8,9 @@ import (
 
 const uninitializedError = "data store was not initialized"
 
-// DefaultDataStore returns an instance of store with initialized values.
-// Also handles enforcement of store implementing the DataStore interface.
+// DefaultDataStore returns an instance of a non-distributed DataStore ready to use.
 func DefaultDataStore() DataStore {
+	// Also handles the enforcement of store implementing the DataStore interface.
 	return &store{
 		data:    map[string]*Average{},
 		RWMutex: sync.RWMutex{},


### PR DESCRIPTION
First pass on wider documentation. I want to test it on older go versions since I suspect it would work several versions back, but 1.9 is probably as far back as I'd need to test based on support I've seen from around the community.

This project will remain unversioned until I get feedback if `avg` really should be an integer. While a float is more precise, returning a float when given an int can be frustrating to the user for actions like comparison in a strictly typed language.