### PR TITLE
Cleanup library interface and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The action counter works exclusively in serialized json strings.
 
 #### Adding an action
 
-Action additions expect a json object containing two attributes: `action` and `time`. `time` must be positive and non-zero, while `action` is not case-sensitive and will always be stored as the lowercase version. Extra key-value pairs will be ignored.
+Action additions expect a json object containing two attributes: `action` and `time`. `time` must be a positive and non-zero number, while `action` is a case-insensitive string and will always be stored as the lowercase version. Extra key-value pairs will be ignored.
 
 If your project requires case-sensitivity or other action name/time specifications, you can define your own object implementing the `DataStore` interface.
 
@@ -41,18 +41,18 @@ Note that `time > 0` is a requirement handled outside of `DataStore`. Any limita
 
 #### Retrieving statistics
 
-Retrieved statistics will be a list of json objects containing an `action` and its corresponding average, `avg`. `action` will be a string and `avg` will always be an integer value, rounded to the nearest integer from the calculated average.
+Retrieved statistics will be a list of json objects containing an `action` and its corresponding average, `avg`. `action` will be a string and `avg` will be a json `number`, which may be a decimal and should be unmarshaled as a float64.
 
 #### The DataStore interface
 
 While this library works concurrently, it may not work for your needs with the default DataStore, such as in the case of a distributed system. If you need custom data storage and retrieval, or different constraints on input, this interface makes room for that.
 
-The `Average` struct has public functions to facilitate retrieving data from other sources, instantiating an `Average` instance, letting it take care of the averaging logic, and then pushing the result back to the database.
+The `Average` struct has public functions to facilitate retrieving data from other sources, instantiating an `Average` instance, letting it take care of the averaging logic, and then pushing the result back to a database.
 
 ---
 ## Installation
 
-This package assumes that you have a working Go environment. It has been tested in go version 1.11, but does not use dependencies that would likely prohibit earlier versions.
+This package assumes that you have a working Go environment. It has been tested in go version 1.11, but does not use dependencies that would likely prohibit earlier versions. If you use an earlier version of go, be sure to run the tests to ensure your version is compatible with this library.
 
 To install the `counter` library, run the following `go get` command
 
@@ -68,10 +68,12 @@ import (
 )
 ```
 
+Note that the project code will be available at `$GOPATH/src/github.com/nat-brown/action-counter` on your system. For more details (such as the case for multiple GOPATHs), you can read details [here](https://golang.org/pkg/cmd/go/internal/get/).
+
 ---
 ## Running Tests
 
-Tests can be run with the `go test` command, or `go test -v` for a list of all tests being run. For more options on running tests, you can read more [here](https://golang.org/pkg/cmd/go/internal/test/).
+Tests can be run from the `action-counter` directory with the `go test` command, or `go test -v` for a list of all tests being run. For more options on running tests, you can read more [here](https://golang.org/pkg/cmd/go/internal/test/).
 
 ---
 ## Go Docs

--- a/action.go
+++ b/action.go
@@ -4,8 +4,8 @@ import "encoding/json"
 
 // actionAddition is the action "request" struct.
 type actionAddition struct {
-	Action string `json:"action"`
-	Time   int    `json:"time"`
+	Action string  `json:"action"`
+	Time   float64 `json:"time"`
 }
 
 // stats aliases a map of an action to an average to enable custom marshaling.
@@ -18,7 +18,7 @@ func (ss stats) MarshalJSON() ([]byte, error) {
 	for action, avg := range ss {
 		list[i] = stat{
 			Action:  action,
-			Average: avg.IntValue(),
+			Average: avg.Value(),
 		}
 		i++
 	}
@@ -27,6 +27,6 @@ func (ss stats) MarshalJSON() ([]byte, error) {
 
 // stat is the action average "response" struct.
 type stat struct {
-	Action  string `json:"action"`
-	Average int    `json:"avg"`
+	Action  string  `json:"action"`
+	Average float64 `json:"avg"`
 }

--- a/action_test.go
+++ b/action_test.go
@@ -18,8 +18,8 @@ func TestStatsMarshal(t *testing.T) {
 				"run":  &Average{value: 3.6},
 			},
 			expected: []string{
-				`[{"action":"jump","avg":5},{"action":"run","avg":4}]`,
-				`[{"action":"run","avg":4},{"action":"jump","avg":5}]`,
+				`[{"action":"jump","avg":5.2},{"action":"run","avg":3.6}]`,
+				`[{"action":"run","avg":3.6},{"action":"jump","avg":5.2}]`,
 			},
 		}, {
 			name:     "empty map",

--- a/action_test.go
+++ b/action_test.go
@@ -9,7 +9,7 @@ func TestStatsMarshal(t *testing.T) {
 	tts := []struct {
 		name     string
 		data     map[string]*Average
-		expected string
+		expected []string // Multiple potential responses because maps aren't ordered.
 	}{
 		{
 			name: "filled data",
@@ -17,14 +17,17 @@ func TestStatsMarshal(t *testing.T) {
 				"jump": &Average{value: 5.2},
 				"run":  &Average{value: 3.6},
 			},
-			expected: `[{"action":"jump","avg":5},{"action":"run","avg":4}]`,
+			expected: []string{
+				`[{"action":"jump","avg":5},{"action":"run","avg":4}]`,
+				`[{"action":"run","avg":4},{"action":"jump","avg":5}]`,
+			},
 		}, {
 			name:     "empty map",
 			data:     map[string]*Average{},
-			expected: "[]",
+			expected: []string{"[]"},
 		}, {
 			name:     "nil map",
-			expected: "[]",
+			expected: []string{"[]"},
 		},
 	}
 	for _, tt := range tts {
@@ -33,8 +36,16 @@ func TestStatsMarshal(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			// Convert to string because slices aren't inherently comparable.
-			assertEqual(t, tt.expected, string(actual), "marshaled data")
+			var matched bool
+			for _, match := range tt.expected {
+				// Convert to string because slices aren't inherently comparable.
+				if string(actual) == match {
+					matched = true
+				}
+			}
+			if !matched {
+				t.Fatalf("\nexpected any of: %v\nactual: %s", tt.expected, actual)
+			}
 		})
 	}
 }

--- a/average.go
+++ b/average.go
@@ -3,7 +3,6 @@ package counter
 import (
 	"errors"
 	"fmt"
-	"math"
 )
 
 // NewAverage initializes a new Average by setting private values.
@@ -25,9 +24,9 @@ type Average struct {
 }
 
 // Add adds a new value to the cumulative average.
-func (a *Average) Add(newVal int) error {
+func (a *Average) Add(newVal float64) error {
 	if newVal <= 0 {
-		return fmt.Errorf("Average.Add called with non-positive value %d", newVal)
+		return fmt.Errorf("Average.Add called with non-positive value %f", newVal)
 	}
 	if a.count+1 < 0 {
 		return errors.New("Average.count overflow - cannot add to this Average")
@@ -37,7 +36,7 @@ func (a *Average) Add(newVal int) error {
 	largerRatio := (newCount - 1) / newCount
 	smallerRatio := float64(1) / newCount
 
-	newAverage := largerRatio*a.value + smallerRatio*float64(newVal)
+	newAverage := largerRatio*a.value + smallerRatio*newVal
 
 	a.value = newAverage
 	a.count++
@@ -50,8 +49,3 @@ func (a *Average) Count() int { return a.count }
 
 // Value returns the calculated average value.
 func (a *Average) Value() float64 { return a.value }
-
-// IntValue returns an integer representation of the average value, rounded.
-func (a *Average) IntValue() int {
-	return int(math.Round(a.value))
-}

--- a/average_test.go
+++ b/average_test.go
@@ -19,8 +19,7 @@ func assertAccurate(t *testing.T, expected, actual float64, failMsg string) {
 
 func TestAverageAddLayering(t *testing.T) {
 	cases := []struct {
-		value           int
-		expectedAverage float64
+		value, expectedAverage float64
 	}{
 		{value: 10, expectedAverage: 10},
 		{value: 5, expectedAverage: 7.5},
@@ -36,7 +35,7 @@ func TestAverageAddLayering(t *testing.T) {
 
 		assertAccurate(t, c.expectedAverage, average.value,
 			fmt.Sprintf(`case %d failed:
-	adding value: %d
+	adding value: %f
 	expected average: %f 
 	actual average: %f`,
 				i, c.value, c.expectedAverage, average.value),
@@ -112,7 +111,7 @@ func TestAverageEdgeCases(t *testing.T) {
 	tts := []struct {
 		name     string
 		avg      Average
-		addValue int
+		addValue float64
 
 		shouldErr   bool
 		errorMsg    string
@@ -146,7 +145,7 @@ func TestAverageEdgeCases(t *testing.T) {
 			},
 			addValue:  0,
 			shouldErr: true,
-			errorMsg:  "Average.Add called with non-positive value 0",
+			errorMsg:  "Average.Add called with non-positive value 0.000000",
 		}, {
 			name: "negative addition",
 			avg: Average{
@@ -155,14 +154,14 @@ func TestAverageEdgeCases(t *testing.T) {
 			},
 			addValue:  -1,
 			shouldErr: true,
-			errorMsg:  "Average.Add called with non-positive value -1",
+			errorMsg:  "Average.Add called with non-positive value -1.000000",
 		}, {
 			name: "max addition",
 			avg: Average{
 				count: 500,
 				value: 10,
 			},
-			addValue: maxInt(),
+			addValue: float64(math.MaxInt64),
 			expectedAvg: Average{
 				count: 501,
 				value: 18409924225259043 + 265.0/501,
@@ -202,22 +201,4 @@ func TestAverageHelpers(t *testing.T) {
 	assertEqual(t, *expected, *actual, "average")
 	assertEqual(t, actual.Value(), actual.value, "value")
 	assertEqual(t, actual.Count(), actual.count, "count")
-}
-
-func TestIntAverage(t *testing.T) {
-	tts := []struct {
-		value    float64
-		expected int
-	}{
-		{value: 0, expected: 0},     // no round
-		{value: 10.1, expected: 10}, // round down
-		{value: 10.5, expected: 11}, // round up
-	}
-
-	for _, tt := range tts {
-		t.Run(fmt.Sprintf("%f rounds to %d", tt.value, tt.expected), func(t *testing.T) {
-			avg := Average{value: tt.value}
-			assertEqual(t, tt.expected, avg.IntValue(), "rounded value")
-		})
-	}
 }

--- a/counter.go
+++ b/counter.go
@@ -18,7 +18,7 @@ type DataStore interface {
 	// Add retrieves the given action and adds the given
 	// value to its average.
 	// See the Average struct for details.
-	Add(action string, value int) error
+	Add(action string, value float64) error
 
 	// Get retrieves all actions and their averages.
 	Get() (map[string]*Average, error)
@@ -67,8 +67,8 @@ func (ac *ActionCounter) GetStats() string {
 
 // add handles the actual adding. It manages data validation and locking.
 func (ac *ActionCounter) add(aa actionAddition) error {
-	if aa.Time < 1 {
-		return fmt.Errorf("non-positive time given to ActionCounter: %d", aa.Time)
+	if aa.Time <= 0 {
+		return fmt.Errorf("non-positive time given to ActionCounter: %f", aa.Time)
 	}
 	// Unlike reading, writing should lock as close to the write call as possible because
 	// no interactions with given data happen after this point.

--- a/counter_test.go
+++ b/counter_test.go
@@ -39,7 +39,7 @@ func TestCounterAddInvalidTime(t *testing.T) {
 		t.Fatalf("got nil instead of expected error")
 	}
 
-	assertEqual(t, "non-positive time given to ActionCounter: -30", err.Error(), "error message")
+	assertEqual(t, "non-positive time given to ActionCounter: -30.000000", err.Error(), "error message")
 	// Ensure we didn't waste time locking.
 	assertEqual(t, false, ts.wasLocked, "was locked")
 }
@@ -86,19 +86,19 @@ func TestCounterAdd(t *testing.T) {
 	assertEqual(t, true, ts.wasUnlocked, "was unlocked")
 }
 
-func TestGetStats(t *testing.T) {
+func TestCounterGetStats(t *testing.T) {
 	ts := newTestStore()
 	ac := ActionCounter{
 		DataStore: &ts,
 	}
 
 	ss := ac.GetStats()
-	assertEqual(t, `[{"action":"swim","avg":31}]`, ss, "stats")
+	assertEqual(t, `[{"action":"swim","avg":30.88}]`, ss, "stats")
 	assertEqual(t, true, ts.wasRLocked, "was read locked")
 	assertEqual(t, true, ts.wasRUnlocked, "was read unlocked")
 }
 
-func TestGetStatsPanic(t *testing.T) {
+func TestCounterGetStatsPanic(t *testing.T) {
 	ts := newTestStore()
 	ac := ActionCounter{
 		DataStore: &ts,
@@ -159,7 +159,7 @@ func (ts *testStore) RUnlock() {
 }
 
 // Add allows testing that the data store errors bubble up.
-func (ts *testStore) Add(action string, value int) error {
+func (ts *testStore) Add(action string, value float64) error {
 	if ts.returnError {
 		return errors.New(innerError)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -46,7 +46,7 @@ func Example() {
 	fmt.Println(sortKeys(output))
 
 	// Output:
-	// [{"action":"jump","avg":31},{"action":"run","avg":3412},{"action":"swim","avg":250}]
+	// [{"action":"jump","avg":30.666666666666664},{"action":"run","avg":3412.333333333333},{"action":"swim","avg":250}]
 }
 
 func ExampleActionCounter() {
@@ -71,8 +71,8 @@ func ExampleActionCounter() {
 
 func sortKeys(output string) string {
 	averages := []struct {
-		Action string `json:"action"`
-		Avg    int    `json:"avg"`
+		Action string  `json:"action"`
+		Avg    float64 `json:"avg"`
 	}{}
 	json.Unmarshal([]byte(output), &averages)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,17 @@
 package counter
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
+// assertEqual is a helper for the most common test assertion.
 func assertEqual(t *testing.T, expected, actual interface{}, name string) {
 	if expected != actual {
 		t.Fatalf("\nexpected %s: %+v\nactual %s: %+v", name, expected, name, actual)
 	}
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
 }

--- a/store.go
+++ b/store.go
@@ -28,7 +28,7 @@ type store struct {
 // Add adds a value to the count for the given action.
 // It will ignore case and assumes that the lock has
 // already been obtained by the caller.
-func (s *store) Add(action string, value int) error {
+func (s *store) Add(action string, value float64) error {
 	if s == nil || s.data == nil {
 		return errors.New(uninitializedError)
 	}


### PR DESCRIPTION
This PR commits to using floats instead of integers. The case was stronger for a float interface rather than an integer one, as the json input doesn't differentiate between the two (specifically, json spec has a generic "number" covering both cases). The decision also cleaned up some odd logic in the code.